### PR TITLE
Correcting vovel counts in two words- EaSiEr and Programming 

### DIFF
--- a/01-js/tests/countVowels.test.js
+++ b/01-js/tests/countVowels.test.js
@@ -3,7 +3,7 @@ const countVowels = require('../medium/countVowels');
 describe('countVowels', () => {
     test('returns the correct count for strings with vowels', () => {
         expect(countVowels('hello')).toBe(2);
-        expect(countVowels('programming')).toBe(4);
+        expect(countVowels('programming')).toBe(3);
         expect(countVowels('OpenAI')).toBe(3);
     });
 
@@ -18,7 +18,7 @@ describe('countVowels', () => {
     });
 
     test('handles case-insensitivity correctly', () => {
-        expect(countVowels('EaSiEr')).toBe(3);
+        expect(countVowels('EaSiEr')).toBe(4);
         expect(countVowels('QUIET')).toBe(3);
         expect(countVowels('aEIOU')).toBe(5);
     });


### PR DESCRIPTION
 The test cases of countVowels.js in medium section of today's assignments. "EaSiEr" has 4 vowels but .tobe(3) is expected  and, "programming" has 3 but .tobe(4) is expected