### PR TITLE
Fix object notation in expenditure-analysis.js

### DIFF
--- a/01-js/easy/expenditure-analysis.js
+++ b/01-js/easy/expenditure-analysis.js
@@ -2,7 +2,7 @@
   Implement a function `calculateTotalSpentByCategory` which takes a list of transactions as parameter
   and return a list of objects where each object is unique category-wise and has total price spent as its value.
   Transaction - an object like { itemName, category, price, timestamp }.
-  Output - [{ category1 - total_amount_spent_on_category1 }, { category2 - total_amount_spent_on_category2 }]
+  Output - [{ category1 : total_amount_spent_on_category1 }, { category2 : total_amount_spent_on_category2 }]
 */
 
 function calculateTotalSpentByCategory(transactions) {


### PR DESCRIPTION
Replaced '-' with ':' in object notation to correctly assign values to keys.