### PR TITLE
changed/corrected path from "file" to "files"

### DIFF
--- a/week-2/02-nodejs/tests/fileServer.test.js
+++ b/week-2/02-nodejs/tests/fileServer.test.js
@@ -65,7 +65,7 @@ describe('API Endpoints', () => {
     test('should serve the requested file', async () => {
       const options = {
         method: 'GET',
-        path: '/file/test-file.txt'
+        path: '/files/test-file.txt'
       };
       const response = await sendRequest(options);
 
@@ -76,7 +76,7 @@ describe('API Endpoints', () => {
     test('should handle file not found', async () => {
       const options = {
         method: 'GET',
-        path: '/file/non-existing-file.txt'
+        path: '/files/non-existing-file.txt'
       };
       const response = await sendRequest(options);
 


### PR DESCRIPTION
Test file, for fileServer i.e. (fileServer.test.js) was having a small issue in the TestCase for getting a particular file e.g. a.txt from the server. Path was having folder name as file, whereas actual folder was files. Made this small change. We could also have changed folder name to file.