### PR TITLE
Update 03-errorcount.js

### DIFF
--- a/week-3/01-middlewares/03-errorcount.js
+++ b/week-3/01-middlewares/03-errorcount.js
@@ -7,7 +7,7 @@ let errorCount = 0;
 
 // You have been given an express server which has a few endpoints.
 // Your task is to
-// 1. Ensure that if there is ever an exception, the end user sees a status code of 404
+// 1. Ensure that if there is ever an exception, the end user sees a status code of 500
 // 2. Maintain the errorCount variable whose value should go up every time there is an exception in any endpoint
 
 app.get('/user', function(req, res) {


### PR DESCRIPTION
changed server error code from 404 to 500

The requirement says that the server must return a status code of 404 when it encounters an error. Shouldn't the actual code be 500?