### PR TITLE
Fix: oldTodoState update logic

### DIFF
--- a/week-4/index.html
+++ b/week-4/index.html
@@ -31,7 +31,7 @@
       // calculate these 3 arrays
       // call addTodo, removeTodo, updateTodo functions on each of the
       // elements
-      oldTodoState = newTodos;
+      oldTodoState = [...newTodos];
     }
 
     function addTodo() {


### PR DESCRIPTION
Assigning `oldTodoState` to to `newTodos` in `updateState` function directly, updates the `todoState` variable. Which in turn  updates the `oldTodoState` with `todoState`. So the `oldTodoState` variable keeps the same state as of `todoState`. 

@hkirat , Please accept this PR.