### PR TITLE
correct the request limit to 4 in ratelimitter.js

### DIFF
--- a/week-3/01-middlewares/02-ratelimitter.js
+++ b/week-3/01-middlewares/02-ratelimitter.js
@@ -4,8 +4,8 @@ const express = require('express');
 const app = express();
 // You have been given an express server which has a few endpoints.
 // Your task is to create a global middleware (app.use) which will
-// rate limit the requests from a user to only 5 request per second
-// If a user sends more than 5 requests in a single second, the server
+// rate limit the requests from a user to only 4 request per second
+// If a user sends more than 4 requests in a single second, the server
 // should block them with a 404.
 // User will be sending in their user id in the header as 'user-id'
 // You have been given a numberOfRequestsForUser object to start off with which


### PR DESCRIPTION
### Fix inconsistency between assignment instructions and test cases in `03-ratelimitter.js`

In **Week-3 01-middlewares Assignment: 03-ratelimitter.js**, the current instruction states:

> "If a user sends more than 5 requests in a single second, the server should block them with a 404."

However, upon reviewing the corresponding test file **`tests/02-ratelimitter.spec.js`**, line 17 specifies:

> `it('5 or more requests return back a 404', function(done) {`

This inconsistency between the assignment instructions and the test case can cause confusion and lead to unnecessary debugging time.

This PR addresses the inconsistency by updating the instruction in the `03-ratelimitter.js` file to match the behavior described in the test case, ensuring clarity and alignment between the code and tests.
